### PR TITLE
fix: correct pandoc highlight-style flag in release workflow

### DIFF
--- a/.github/workflows/release-pdf.yml
+++ b/.github/workflows/release-pdf.yml
@@ -32,7 +32,7 @@ jobs:
             --pdf-engine=pdflatex \
             --shift-heading-level-by=-1 \
             --lua-filter=.github/spec-pdf/table-style.lua \
-            --syntax-highlighting=tango \
+            --highlight-style=tango \
             --toc \
             --toc-depth=3 \
             -V version="${{ github.event.release.tag_name }}" \


### PR DESCRIPTION
## Summary
- Fixes the release PDF workflow which failed on v0.1 because `--syntax-highlighting` is not a valid pandoc option
- Changes to the correct flag: `--highlight-style=tango`

## Test plan
- [ ] Merge to develop, then merge develop to main
- [ ] Delete and recreate the v0.1 release to re-trigger the workflow
- [ ] Verify PDF is attached to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)