### PR TITLE
feat: add workflow to create release tags via GitHub UI

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,57 @@
+name: Create Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.2-draft.3, v0.3)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch to tag (draft releases must use develop)'
+        required: true
+        default: 'develop'
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate tag format
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+(-(draft|rc)\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid tag format '${TAG}'. Expected: v0.2, v0.2-draft.3, v0.2-rc.1"
+            exit 1
+          fi
+
+      - name: Validate branch for draft tags
+        run: |
+          TAG="${{ inputs.tag }}"
+          BRANCH="${{ inputs.branch }}"
+          if [[ "${TAG}" == *-draft* && "${BRANCH}" != "develop" ]]; then
+            echo "::error::Draft tags must be created on the develop branch, got '${BRANCH}'"
+            exit 1
+          fi
+
+      - name: Check tag does not already exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api repos/${{ github.repository }}/git/refs/tags/${{ inputs.tag }} >/dev/null 2>&1; then
+            echo "::error::Tag '${{ inputs.tag }}' already exists"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Create and push tag
+        run: |
+          git tag "${{ inputs.tag }}"
+          git push origin "${{ inputs.tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ This project follows [Semantic Versioning](https://semver.org/) for specificatio
 
 ---
 
+## [0.2-draft.3] — March 2026
+
+**Third draft snapshot of v0.2 for community review.**
+
+### Changed
+
+- Rebranded all references from DPG Labs / dpglabs / thedpg to OPSF (Open Privacy Standards Foundation) (#19)
+- Added GitHub issue/PR templates and CODEOWNERS for public collaboration (#17)
+- Added workflow to notify pct-site on spec releases (#13)
+
+---
+
 ## Upcoming: [0.2]
 
 Proposed for the next version based on public comment period. Issues and PRs welcome via GitHub or info@opsf.org.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project follows [Semantic Versioning](https://semver.org/) for specificatio
 
 ---
 
+## [0.2-draft.3] — March 2026
+
+**Third draft snapshot of v0.2 for community review.**
+
+### Changed
+
+- Rebranded all references from DPG Labs / dpglabs / thedpg to OPSF (Open Privacy Standards Foundation) (#19)
+- Added GitHub issue/PR templates and CODEOWNERS for public collaboration (#17)
+- Added workflow to notify pct-site on spec releases (#13)
+
+---
+
 ## [0.1] — March 2026
 
 **Initial draft for public comment.**
@@ -26,18 +38,6 @@ This project follows [Semantic Versioning](https://semver.org/) for specificatio
 - Appendix B: Controlled purpose vocabulary (16 standard terms)
 
 **Authors:** OPSF (Open Privacy Standards Foundation) · [opsf.org](https://opsf.org)
-
----
-
-## [0.2-draft.3] — March 2026
-
-**Third draft snapshot of v0.2 for community review.**
-
-### Changed
-
-- Rebranded all references from DPG Labs / dpglabs / thedpg to OPSF (Open Privacy Standards Foundation) (#19)
-- Added GitHub issue/PR templates and CODEOWNERS for public collaboration (#17)
-- Added workflow to notify pct-site on spec releases (#13)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Draft tags are used to publish snapshots of `develop` for community review befor
 
 - `v0.2-draft.1` — First draft snapshot of v0.2 for community review
 - `v0.2-draft.2` — Revised draft after incorporating feedback
-- `v0.2-draft.3` — Further revision, etc.
+- `v0.2-draft.3` — Rebrand to OPSF, public collaboration infrastructure
 
 Draft tags are created on `develop` (not `main`). They are **retained permanently** as a historical record of what was reviewed — they are not deleted when the final version is released.
 


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` workflow (`create-release.yml`) that creates and pushes a release tag from the GitHub Actions UI
- Validates tag format (`v0.2`, `v0.2-draft.3`, `v0.2-rc.1`)
- Enforces draft tags target `develop` only
- Checks tag doesn't already exist before creating
- The existing `release-pdf.yml` picks up the tag push automatically to build the PDF and create the GitHub release

## Test plan
- [ ] Trigger workflow manually with a valid draft tag (e.g. `v0.2-draft.3`) on `develop`
- [ ] Verify invalid tag formats are rejected (e.g. `abc`, `0.2`)
- [ ] Verify draft tags on non-develop branches are rejected
- [ ] Verify duplicate tags are rejected
- [ ] Verify `release-pdf.yml` triggers after tag is created

https://claude.ai/code/session_01FycnS3GvXhV3YGH3h2gS5A