### PR TITLE
fix: use git push for tag creation in release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,20 +47,11 @@ jobs:
             exit 1
           fi
 
-      - name: Get branch SHA
-        id: sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SHA=$(gh api repos/${{ github.repository }}/git/refs/heads/${{ inputs.branch }} --jq '.object.sha')
-          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "Tagging commit ${SHA} on branch ${{ inputs.branch }}"
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.branch }}
 
-      - name: Create tag via API
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push tag
         run: |
-          gh api repos/${{ github.repository }}/git/refs \
-            -f ref="refs/tags/${{ inputs.tag }}" \
-            -f sha="${{ steps.sha.outputs.sha }}"
-          echo "Created tag ${{ inputs.tag }} on ${{ steps.sha.outputs.sha }}"
+          git tag "${{ inputs.tag }}"
+          git push origin "${{ inputs.tag }}"


### PR DESCRIPTION
## Summary
- Replaces the `gh api` approach for tag creation with `git checkout` + `git push`
- The API endpoint returned 422 due to tag protection rules; `git push` works when GitHub Actions has a bypass in the tag ruleset
- Requires adding a GitHub Actions bypass to the tag protection ruleset

## Test plan
- [ ] Add GitHub Actions bypass to the tag ruleset
- [ ] Trigger the Create Draft Release workflow with `v0.2-draft.3` on `develop`
- [ ] Verify the tag is created and `release-pdf.yml` triggers

https://claude.ai/code/session_01FycnS3GvXhV3YGH3h2gS5A