### PR TITLE
fix: use git push for tag creation instead of API

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,20 +47,11 @@ jobs:
             exit 1
           fi
 
-      - name: Get branch SHA
-        id: sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SHA=$(gh api repos/${{ github.repository }}/git/refs/heads/${{ inputs.branch }} --jq '.object.sha')
-          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "Tagging commit ${SHA} on branch ${{ inputs.branch }}"
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.branch }}
 
-      - name: Create tag via API
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push tag
         run: |
-          gh api repos/${{ github.repository }}/git/refs \
-            -f ref="refs/tags/${{ inputs.tag }}" \
-            -f sha="${{ steps.sha.outputs.sha }}"
-          echo "Created tag ${{ inputs.tag }} on ${{ steps.sha.outputs.sha }}"
+          git tag "${{ inputs.tag }}"
+          git push origin "${{ inputs.tag }}"


### PR DESCRIPTION
The gh api refs endpoint returned 422 due to tag protection rules. Switch to git checkout + git push, which works when GitHub Actions has a bypass in the tag ruleset.

https://claude.ai/code/session_01FycnS3GvXhV3YGH3h2gS5A

## Summary

<!-- Brief description of what this PR changes and why -->

## Related Issue

<!-- Link to the issue this addresses, e.g. Fixes #12 -->

## Type of Change

- [ ] Correction (typo, factual error, broken link)
- [ ] New example token or scenario
- [ ] Schema improvement
- [ ] Extension proposal (RFC)
- [ ] Other (describe below)

## Sections Affected

<!-- List spec section numbers, e.g. § 4.3, § 7.1 -->
