### PR TITLE
Rebrand from DPG Labs to OPSF (Open Privacy Standards Foundation)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default owners for the PCT specification repository.
 # These users will be requested for review on all PRs.
 
-* @dpglabs/maintainers
+* @opsf-org/maintainers

--- a/.github/spec-pdf/template.tex
+++ b/.github/spec-pdf/template.tex
@@ -41,7 +41,7 @@
 \fancyhf{}
 \fancyhead[L]{\small\color{pctgray}Privacy Claims Token --- Open Specification $if(version)$$version$$else$v0.1$endif$}
 \fancyhead[R]{}
-\fancyfoot[L]{\footnotesize\color{pctgray}\textcopyright\ 2026 DPG Labs \pctsep{} The DPG \pctsep{} dpglabs.io \pctsep{} CC BY 4.0}
+\fancyfoot[L]{\footnotesize\color{pctgray}\textcopyright\ 2026 OPSF (Open Privacy Standards Foundation) \pctsep{} opsf.org \pctsep{} CC BY 4.0}
 \fancyfoot[C]{}
 \fancyfoot[R]{\small\color{pctgray}Page \thepage}
 \renewcommand{\headrulewidth}{0.4pt}
@@ -198,7 +198,7 @@ $highlighting-macros$
 % ── PDF Metadata ─────────────────────────────────────────────────
 \hypersetup{
   pdftitle={Privacy Claims Token (PCT) — Open Specification},
-  pdfauthor={DPG Labs · The DPG},
+  pdfauthor={OPSF (Open Privacy Standards Foundation)},
   pdfsubject={PCT Specification $if(version)$$version$$else$v0.1$endif$},
   pdfkeywords={privacy, data governance, JWT, claims token, specification}
 }
@@ -243,8 +243,8 @@ $endif$
   $if(version)$$version$$else$0.1$endif$ \pctsep{} Draft for Public Comment\\[0.5em]
   $if(date)$$date$$else$March 2026$endif$\\[0.5em]
   Released under CC BY 4.0\\[0.5em]
-  DPG Labs \pctsep{} The DPG\\[0.5em]
-  \href{https://dpglabs.io}{\color{pctgold}dpglabs.io}
+  OPSF (Open Privacy Standards Foundation)\\[0.5em]
+  \href{https://opsf.org}{\color{pctgold}opsf.org}
 }
 \end{tcolorbox}
 
@@ -266,7 +266,7 @@ $endif$
 \rowcolor{pctnavy} \textcolor{white}{\textbf{Version}} & \textcolor{white}{\textbf{$if(version)$$version$$else$0.1$endif$ \pctsep{} Draft for Public Comment}} \\
 \textbf{Date} & $if(date)$$date$$else$March 2026$endif$ \\
 \hline
-\rowcolor{codebg} \textbf{Authors} & DPG Labs \pctsep{} The DPG \pctsep{} \href{https://dpglabs.io}{dpglabs.io} \\
+\rowcolor{codebg} \textbf{Authors} & OPSF (Open Privacy Standards Foundation) \pctsep{} \href{https://opsf.org}{opsf.org} \\
 \hline
 \textbf{Licence} & Creative Commons Attribution 4.0 International (CC BY 4.0) \\
 \end{longtable}
@@ -277,7 +277,7 @@ $endif$
 
 \vspace{1em}
 \begin{center}
-{\small\color{pctgray}\textcopyright\ 2026 DPG Labs \pctsep{} CC BY 4.0}
+{\small\color{pctgray}\textcopyright\ 2026 OPSF (Open Privacy Standards Foundation) \pctsep{} CC BY 4.0}
 \end{center}
 
 % ── Body ─────────────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,10 @@ This project follows [Semantic Versioning](https://semver.org/) for specificatio
 - Appendix A: Full JSON Schema (Draft 2020-12)
 - Appendix B: Controlled purpose vocabulary (16 standard terms)
 
-**Authors:** DPG Labs · The DPG · [dpglabs.io](https://dpglabs.io)
+**Authors:** OPSF (Open Privacy Standards Foundation) · [opsf.org](https://opsf.org)
 
 ---
 
 ## Upcoming: [0.2]
 
-Proposed for the next version based on public comment period. Issues and PRs welcome via GitHub or pct@dpglabs.io.
+Proposed for the next version based on public comment period. Issues and PRs welcome via GitHub or info@opsf.org.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ For **substantive changes to the core specification** — new required fields, c
 
 If you prefer not to use GitHub, comments may be submitted by email to:
 
-**pct@dpglabs.io**
+**info@opsf.org**
 
 Please include the section number and a clear description of your comment or proposed change. Email submissions will be reviewed and, where appropriate, converted to GitHub Issues for tracking.
 
@@ -99,4 +99,4 @@ This project follows a simple standard: be respectful, be constructive, and focu
 
 ---
 
-*DPG Labs · The DPG · [dpglabs.io](https://dpglabs.io)*
+*OPSF (Open Privacy Standards Foundation) · [opsf.org](https://opsf.org)*

--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 Creative Commons Attribution 4.0 International (CC BY 4.0)
 
-Copyright 2026 DPG Labs / The DPG
+Copyright 2026 OPSF (Open Privacy Standards Foundation)
 
 You are free to:
 
@@ -12,7 +12,7 @@ The licensor cannot revoke these freedoms as long as you follow the licence term
 
 Under the following terms:
 
-  Attribution — You must give appropriate credit to DPG Labs / The DPG, provide a link to the licence,
+  Attribution — You must give appropriate credit to OPSF (Open Privacy Standards Foundation), provide a link to the licence,
   and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the
   licensor endorses you or your use.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This is a draft for public comment. Contributions of all kinds are welcome:
 
 Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for details, or open an issue.
 
-**Comment by email:** pct@dpglabs.io
+**Comment by email:** info@opsf.org
 
 ---
 
@@ -150,9 +150,9 @@ Anyone may implement, extend, or build upon it freely, provided attribution is g
 
 ## Authors
 
-**DPG Labs · The DPG**
+**OPSF (Open Privacy Standards Foundation)**
 
-[dpglabs.io](https://dpglabs.io)
+[opsf.org](https://opsf.org)
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -4,7 +4,7 @@
 
 March 2026
 
-**Specification authors:** DPG Labs · The DPG · [dpglabs.io](https://dpglabs.io)
+**Specification authors:** OPSF (Open Privacy Standards Foundation) · [opsf.org](https://opsf.org)
 
 ---
 
@@ -566,7 +566,7 @@ This example shows a PCT that would result in an ALLOW decision for a clinical a
   "issued_at": 1743000000,
   "valid_from": 1743000000,
   "expires_at": 1774536000,
-  "issuer": "https://orchestrator.dpglabs.io",
+  "issuer": "https://orchestrator.opsf.org",
   "subject_id": "dataset:patient-cohort-2026-03",
   "subject_type": "ai_interaction",
   "data_origin": "GB",
@@ -732,7 +732,7 @@ The following JSON Schema (Draft 2020-12) defines the complete structure of a PC
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://pct.dpglabs.io/schema/0.1/pct.json",
+  "$id": "https://pct.opsf.org/schema/0.1/pct.json",
   "title": "Privacy Claims Token",
   "type": "object",
   "required": [
@@ -825,16 +825,16 @@ The following values are defined as the standard controlled vocabulary for the `
 
 | Version | Date | Notes |
 |---------|------|-------|
-| **0.1** | March 2026 | Initial draft for public comment. Core schema, lifecycle, signing model, data binding and integrity verification, enforcement API, audit record, four regulatory extension namespaces, example scenarios, and JSON Schema appendix. Authored by DPG Labs / The DPG. |
+| **0.1** | March 2026 | Initial draft for public comment. Core schema, lifecycle, signing model, data binding and integrity verification, enforcement API, audit record, four regulatory extension namespaces, example scenarios, and JSON Schema appendix. Authored by OPSF (Open Privacy Standards Foundation). |
 
 ---
 
 Comments, corrections, and proposed extensions for version 0.2 should be submitted to:
 
-**pct@dpglabs.io**
+**info@opsf.org**
 
-[github.com/dpglabs/pct-spec](https://github.com/dpglabs/pct-spec)
+[github.com/opsf-org/pct-spec](https://github.com/opsf-org/pct-spec)
 
 ---
 
-*Privacy Claims Token Specification v0.1 · Released under CC BY 4.0 · DPG Labs · [dpglabs.io](https://dpglabs.io)*
+*Privacy Claims Token Specification v0.1 · Released under CC BY 4.0 · OPSF (Open Privacy Standards Foundation) · [opsf.org](https://opsf.org)*

--- a/examples/scenario-1-allow-uk-clinical.json
+++ b/examples/scenario-1-allow-uk-clinical.json
@@ -5,7 +5,7 @@
   "pct": {
     "header": {
       "alg": "RS256",
-      "kid": "dpg-labs-key-2026-03",
+      "kid": "pct-key-2026-03",
       "typ": "PCT",
       "pct_version": "0.1"
     },
@@ -14,7 +14,7 @@
       "issued_at": 1743000000,
       "valid_from": 1743000000,
       "expires_at": 1774536000,
-      "issuer": "https://orchestrator.dpglabs.io",
+      "issuer": "https://orchestrator.opsf.org",
       "subject_id": "dataset:patient-cohort-2026-03",
       "subject_type": "ai_interaction",
       "data_origin": "GB",

--- a/examples/scenario-2-block-jurisdiction.json
+++ b/examples/scenario-2-block-jurisdiction.json
@@ -6,7 +6,7 @@
   "pct": {
     "header": {
       "alg": "RS256",
-      "kid": "dpg-labs-key-2026-03",
+      "kid": "pct-key-2026-03",
       "typ": "PCT",
       "pct_version": "0.1"
     },
@@ -15,7 +15,7 @@
       "issued_at": 1743000000,
       "valid_from": 1743000000,
       "expires_at": 1774536000,
-      "issuer": "https://orchestrator.dpglabs.io",
+      "issuer": "https://orchestrator.opsf.org",
       "subject_id": "dataset:patient-cohort-2026-03",
       "subject_type": "ai_interaction",
       "data_origin": "GB",

--- a/examples/scenario-3-block-purpose.json
+++ b/examples/scenario-3-block-purpose.json
@@ -6,7 +6,7 @@
   "pct": {
     "header": {
       "alg": "RS256",
-      "kid": "dpg-labs-key-2026-03",
+      "kid": "pct-key-2026-03",
       "typ": "PCT",
       "pct_version": "0.1"
     },
@@ -15,7 +15,7 @@
       "issued_at": 1743000000,
       "valid_from": 1743000000,
       "expires_at": 1774536000,
-      "issuer": "https://orchestrator.dpglabs.io",
+      "issuer": "https://orchestrator.opsf.org",
       "subject_id": "dataset:patient-cohort-2026-03",
       "subject_type": "ai_interaction",
       "data_origin": "GB",

--- a/examples/scenario-4-block-multiple.json
+++ b/examples/scenario-4-block-multiple.json
@@ -6,7 +6,7 @@
   "pct": {
     "header": {
       "alg": "RS256",
-      "kid": "dpg-labs-key-2026-03",
+      "kid": "pct-key-2026-03",
       "typ": "PCT",
       "pct_version": "0.1"
     },
@@ -15,7 +15,7 @@
       "issued_at": 1743000000,
       "valid_from": 1743000000,
       "expires_at": 1774536000,
-      "issuer": "https://orchestrator.dpglabs.io",
+      "issuer": "https://orchestrator.opsf.org",
       "subject_id": "dataset:clinical-trial-protocol-A-2026",
       "subject_type": "ai_interaction",
       "data_origin": "DE",

--- a/schema/pct-schema-0.1.json
+++ b/schema/pct-schema-0.1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://pct.dpglabs.io/schema/0.1/pct.json",
+  "$id": "https://pct.opsf.org/schema/0.1/pct.json",
   "title": "Privacy Claims Token",
   "description": "JSON Schema for PCT payload validation — Privacy Claims Token Specification v0.1",
   "type": "object",


### PR DESCRIPTION
## Summary

This PR updates all references throughout the PCT specification repository from "DPG Labs · The DPG" to "OPSF (Open Privacy Standards Foundation)" and updates associated URLs and contact information accordingly.

Changes include:
- Organization name and branding in specification documents
- Website URLs (dpglabs.io → opsf.org)
- Email contact (pct@dpglabs.io → info@opsf.org)
- GitHub organization references (dpglabs → opsf-org)
- Example token issuer URLs and key identifiers
- JSON Schema identifiers
- PDF template metadata and footer
- Copyright and license attribution
- CODEOWNERS team reference

## Related Issue

N/A

## Type of Change

- [x] Correction (organizational rebranding)
- [ ] New example token or scenario
- [ ] Schema improvement
- [ ] Extension proposal (RFC)
- [ ] Other

## Sections Affected

- § 0 (Title page, authors, contact information)
- § 4.2 (Example scenario - issuer URL)
- § 8 (JSON Schema definition)
- § 9 (Version history and contact)
- Appendix A (JSON Schema)
- All supporting documentation (README, CONTRIBUTING, CHANGELOG, LICENSE)
- All example tokens (scenarios 1-4)

## Notes

This is a comprehensive rebranding update affecting documentation, examples, and metadata. All functional schema definitions remain unchanged; only identifiers and organizational references are updated.

https://claude.ai/code/session_01XTRidUd1dEW3N4CrWc5bri