### PR TITLE
Remove banner image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img src="assets/banner.png" alt="Proof Claims Token — An open standard for portable, cryptographically signed data obligation tokens." width="100%">
-</p>
-
 # Proof Claims Token (PCT) — Open Specification
 
 **Version 0.1 · Draft for Public Comment · March 2026**


### PR DESCRIPTION
## Summary

Removes the leading banner block from `README.md` (4 lines: the `<p align="center">` wrapper with the `assets/banner.png` image and the trailing blank line). The README now opens directly with the `# Proof Claims Token (PCT) — Open Specification` heading.

The image file `assets/banner.png` is left in the repo and is not deleted.

## Companion PR

A parallel PR with the same change targets `main` so the banner is removed on both branches without requiring a `develop → main` merge.

## Test plan

- [ ] README renders with the title heading at the top, no banner
- [ ] No broken image references introduced

https://claude.ai/code/session_0138SZmecoFi9gGxXHTXzL5d

---
_Generated by [Claude Code](https://claude.ai/code/session_0138SZmecoFi9gGxXHTXzL5d)_